### PR TITLE
Adding .coveragerc and setup.cfg

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+# .coveragerc
+[run]
+source=service
+
+[report]
+show_missing = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,11 @@
+[nosetests]
+verbosity=2
+with-spec=1
+spec-color=1
+with-coverage=1
+cover-erase=1
+cover-package=service
+with-xunit=1
+xunit-file=./unittests.xml
+cover-xml=1
+cover-xml-file=./coverage.xml


### PR DESCRIPTION
`nose` is already defined in our `requirements.txt` and installed as part of running `vagrant up`. This should ensure that tests are run properly when `nosetests` is executed from within the repository. 