### PR TITLE
Adding a DELETE endpoint + tests

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MESSAGES CONTROL]
+disable=E1101

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn --bind 0.0.0.0:5000 --log-level=info service:app

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,0 +1,6 @@
+import os
+
+PORT = os.getenv("PORT", "5000")
+bind = "0.0.0.0:" + PORT
+workers = 1
+log_level = "info"

--- a/service/__init__.py
+++ b/service/__init__.py
@@ -14,9 +14,8 @@ from flask import Flask
 app = Flask(__name__)
 app.config.from_object("config")
 
-# Import the models after the Flask app is created
-# TODO: Also import routes and error handlers
-from service import models, routes
+# Import the models, routes and error handlers after the Flask app is created
+from service import models, routes, error_handlers
 
 # Set up logging for production
 print("Configuring logging for {}...".format(__name__))

--- a/service/error_handlers.py
+++ b/service/error_handlers.py
@@ -1,0 +1,84 @@
+# TODO: Copyright header
+
+"""
+Module: error_handlers
+"""
+from flask import jsonify
+
+from service.models import DataValidationError
+from . import app, status
+
+
+@app.errorhandler(DataValidationError)
+def request_validation_error(error):
+    """Handles Value Errors from bad data"""
+    return bad_request(error)
+
+
+@app.errorhandler(status.HTTP_400_BAD_REQUEST)
+def bad_request(error):
+    """Handles bad reuests with 400_BAD_REQUEST"""
+    message = str(error)
+    app.logger.warning(message)
+    return (
+        jsonify(
+            status=status.HTTP_400_BAD_REQUEST, error="Bad Request", message=message
+        ),
+        status.HTTP_400_BAD_REQUEST,
+    )
+
+
+@app.errorhandler(status.HTTP_404_NOT_FOUND)
+def not_found(error):
+    """Handles resources not found with 404_NOT_FOUND"""
+    message = str(error)
+    app.logger.warning(message)
+    return (
+        jsonify(status=status.HTTP_404_NOT_FOUND, error="Not Found", message=message),
+        status.HTTP_404_NOT_FOUND,
+    )
+
+
+@app.errorhandler(status.HTTP_405_METHOD_NOT_ALLOWED)
+def method_not_supported(error):
+    """Handles unsuppoted HTTP methods with 405_METHOD_NOT_SUPPORTED"""
+    message = str(error)
+    app.logger.warning(message)
+    return (
+        jsonify(
+            status=status.HTTP_405_METHOD_NOT_ALLOWED,
+            error="Method not Allowed",
+            message=message,
+        ),
+        status.HTTP_405_METHOD_NOT_ALLOWED,
+    )
+
+
+@app.errorhandler(status.HTTP_415_UNSUPPORTED_MEDIA_TYPE)
+def mediatype_not_supported(error):
+    """Handles unsuppoted media requests with 415_UNSUPPORTED_MEDIA_TYPE"""
+    message = str(error)
+    app.logger.warning(message)
+    return (
+        jsonify(
+            status=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+            error="Unsupported media type",
+            message=message,
+        ),
+        status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+    )
+
+
+@app.errorhandler(status.HTTP_500_INTERNAL_SERVER_ERROR)
+def internal_server_error(error):
+    """Handles unexpected server error with 500_SERVER_ERROR"""
+    message = str(error)
+    app.logger.error(message)
+    return (
+        jsonify(
+            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            error="Internal Server Error",
+            message=message,
+        ),
+        status.HTTP_500_INTERNAL_SERVER_ERROR,
+    )

--- a/service/models.py
+++ b/service/models.py
@@ -28,8 +28,6 @@ def init_db(app):
 class DataValidationError(Exception):
     """Used for an data validation errors when deserializing"""
 
-    pass
-
 
 class Condition(Enum):
     """Enumeration of valid Item conditions"""
@@ -66,6 +64,12 @@ class InventoryItem(db.Model):
         logger.info("Creating %s", self.sku)
         self.id = None  # id must be none to generate next primary key
         db.session.add(self)
+        db.session.commit()
+
+    def delete(self):
+        """Removes a Inventory item from the database"""
+        logger.info("Deleting %s", self.sku)
+        db.session.delete(self)
         db.session.commit()
 
     def update(self):
@@ -134,3 +138,9 @@ class InventoryItem(db.Model):
         """
         logger.info("Processing lookup for id %s ...", inventory_item_id)
         return cls.query.get(inventory_item_id)
+
+    @classmethod
+    def all(cls):
+        """Returns all of the InventoryItems in the database"""
+        logger.info("Returning a list of all inventory items...")
+        return cls.query.all()

--- a/service/routes.py
+++ b/service/routes.py
@@ -9,17 +9,11 @@ GET / - return some useful information about the service
 PUT /inventories/{ID}/in-stock - update the in_stock attribute of Inventory model to True
 PUT /inventories/{ID}/out-of-stock - update the in_stock attribute of Inventory model to False
 """
-import os
-import sys
-import logging
-from flask import Flask, jsonify, request, url_for, make_response, abort
-from . import status  # HTTP Status Codes
+from flask import jsonify, request, url_for, make_response, abort
 from werkzeug.exceptions import NotFound
 
-# For this example we'll use SQLAlchemy, a popular ORM that supports a
-# variety of backends including SQLite, MySQL, and PostgreSQL
-from flask_sqlalchemy import SQLAlchemy
-from service.models import InventoryItem, DataValidationError
+from service.models import InventoryItem
+from . import status  # HTTP Status Codes
 
 # Import Flask application
 from . import app
@@ -33,10 +27,9 @@ def index():
     Return some useful information about the service, including
     service name, version, and the resource URL
     """
-    url = request.base_url + 'inventories'
+    url = request.base_url + "inventories"
     # url=url_for('list_items', _external=True)
-    return jsonify(name='Inventory Service', version='1.0', url=url), status.HTTP_200_OK
-
+    return jsonify(name="Inventory Service", version="1.0", url=url), status.HTTP_200_OK
 
 
 ######################################################################
@@ -87,12 +80,25 @@ def update_in_stock(inventory_item_id):
     return make_response(jsonify(inventory_item.serialize()), status.HTTP_200_OK)
 
 
+@app.route("/inventories/<int:inventory_item_id>", methods=["DELETE"])
+def delete_inventory_items(inventory_item_id):
+    """
+    Delete an inventory item
+
+    This endpoint will delete a InventoryItem based the id specified in the path
+    """
+    app.logger.info("Request to delete inventory item with id: %s", inventory_item_id)
+    inventory_item_id = InventoryItem.find(inventory_item_id)
+    if inventory_item_id:
+        inventory_item_id.delete()
+
+    app.logger.info("Finished deleting inventory item [%s]", inventory_item_id)
+    return make_response("", status.HTTP_204_NO_CONTENT)
+
+
 ######################################################################
 #  U T I L I T Y   F U N C T I O N S
 ######################################################################
-"""
-This method is copied straight out of the lab. Please modify if needed.
-"""
 
 
 def check_content_type(media_type):

--- a/tests/test_inventory_items.py
+++ b/tests/test_inventory_items.py
@@ -97,20 +97,6 @@ class TestInventoryItemModel(unittest.TestCase):
         self.assertIn("in_stock", data)
         self.assertEqual(data["in_stock"], item.in_stock)
 
-    def test_create_a_inventory_item(self):
-        """Create an inventory item and assert that it exists"""
-        inventory_item = InventoryItem(
-            sku="fido",
-            count=10,
-            condition="New",
-            restock_level=2,
-            restock_amount=20,
-            in_stock=True,
-        )
-        self.assertTrue(inventory_item != None)
-        self.assertEqual(inventory_item.id, None)
-        self.assertEqual(inventory_item.sku, "fido")
-
     def test_deserialize(self):
         """Test deserialization of an InventoryItem"""
         data = {
@@ -187,3 +173,32 @@ class TestInventoryItemModel(unittest.TestCase):
         )
         expected = "<Inventory item FAKE1234 id=None>"
         self.assertEqual(item.__repr__(), expected)
+
+    def test_create(self):
+        """Create an inventory item and assert that it exists"""
+        inventory_item = InventoryItem(
+            sku="FAKESKU123",
+            count=10,
+            condition="New",
+            restock_level=2,
+            restock_amount=20,
+            in_stock=True,
+        )
+        self.assertTrue(inventory_item != None)
+        self.assertEqual(inventory_item.id, None)
+        self.assertEqual(inventory_item.sku, "FAKESKU123")
+        self.assertEqual(inventory_item.condition, Condition.New.name)
+        self.assertEqual(inventory_item.restock_amount, 20)
+        self.assertEqual(inventory_item.in_stock, True)
+
+    def test_delete(self):
+        """Ensure InventoryItem.delete() behaves as expected"""
+        inventory_item = InventoryItemFactory()
+        inventory_item.create()
+
+        # Verify that we have exactly one inventory item first
+        self.assertEqual(len(InventoryItem.all()), 1)
+
+        # Then delete the inventory item, and ensure it's no longer in the database
+        inventory_item.delete()
+        self.assertEqual(len(InventoryItem.all()), 0)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -63,16 +63,36 @@ class TestInventoryItemServer(unittest.TestCase):
     def tearDown(self):
         db.session.remove()
         db.drop_all()
-    
+
+    def _create_inventory_items(self, count: int):
+        """Factory method to create inventory items in bulk"""
+        inventory_items = []
+        for _ in range(count):
+            test_inventory_item = InventoryItemFactory()
+            resp = self.app.post(
+                BASE_URL,
+                json=test_inventory_item.serialize(),
+                content_type=CONTENT_TYPE_JSON,
+            )
+            self.assertEqual(
+                resp.status_code,
+                status.HTTP_201_CREATED,
+                "Could not create test inventory item",
+            )
+            new_inventory_item = resp.get_json()
+            test_inventory_item.id = new_inventory_item["id"]
+            inventory_items.append(test_inventory_item)
+        return inventory_items
+
     def test_index(self):
         """
         Test the index page
         Return some useful information when root url is requested
         """
-        resp = self.app.get('/')
+        resp = self.app.get("/")
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         data = resp.get_json()
-        self.assertEqual(data['name'], 'Inventory Service')
+        self.assertEqual(data["name"], "Inventory Service")
 
     def test_create_inventory_item(self):
         """Create a new Inventory item"""
@@ -104,7 +124,7 @@ class TestInventoryItemServer(unittest.TestCase):
         )
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
 
-        # update the pet
+        # update the inventory item
         new_inventory_item = resp.get_json()
         logging.debug(new_inventory_item)
         new_inventory_item["in_stock"] = False
@@ -116,3 +136,20 @@ class TestInventoryItemServer(unittest.TestCase):
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         updated_inventory_item = resp.get_json()
         self.assertEqual(updated_inventory_item["in_stock"], False)
+
+    def test_delete_inventory_item(self):
+        """Delete an inventory item"""
+        # Create a dummy inventory item
+        test_inventory_item = self._create_inventory_items(1)[0]
+
+        # Send a request to delete the dummy item
+        resp = self.app.delete(
+            "{0}/{1}".format(BASE_URL, test_inventory_item.id),
+            content_type=CONTENT_TYPE_JSON,
+        )
+
+        # Ensure the response code is 204 and contains no data
+        self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(len(resp.data), 0)
+
+        # TODO: Once the query endpoint is ready, verify that the pet is actually gone


### PR DESCRIPTION
I also added a `.pylintrc` file for configuring PyLint, a `gunicorn.conf.py` for the gunicorn web server used by Flask, and a `Procfile` for using `honcho`. 

You can now run `honcho start` to start our service with a production server. 

We should set up Travis CI and CodeCov soon, but just to make it easy:

```
vagrant@ubuntu:/vagrant$ nosetests

Test Cases for InventoryItem Model
- Create an inventory item and assert that it exists
- Ensure InventoryItem.delete() behaves as expected
- Test deserialization of an InventoryItem
- Test deserialization of an InventoryItem with bad data
- Test deserialization of an InventoryItem with missing data
- Ensure string representation of an InventoryItem is correct
- Test serialization of an InventoryItem

InventoryItem Server Tests
- Ensure a 400 is returned if the request data is bad
- Create a new Inventory item
- Delete an inventory item
- Ensure a 404 is returned if a DELETE is sent for a nonexistant item
- Test the index page
        Return some useful information when root url is requested
- Ensure a 405 is returned if a non-GET request is sent to /
- Ensure a 415 is raised if an unsupported media type is used
- Update in stock status for an inventory item

----------------------------------------------------------------------
XML: /vagrant/unittests.xml
Name                        Stmts   Miss  Cover   Missing
---------------------------------------------------------
service/__init__.py            26      4    85%   34, 44-47
service/error_handlers.py      32      3    91%   75-77
service/models.py              70      1    99%   83
service/routes.py              47      1    98%   74
service/status.py              46      0   100%
---------------------------------------------------------
TOTAL                         221      9    96%
----------------------------------------------------------------------
Ran 15 tests in 0.539s

OK
```
And PyLint:
```
vagrant@ubuntu:/vagrant$ pylint service/
************* Module service
service/__init__.py:1:2: W0511: TODO: Copyright header (fixme)
service/__init__.py:14:0: C0103: Constant name "app" doesn't conform to UPPER_CASE naming style (invalid-name)
service/__init__.py:18:0: C0413: Import "from service import models, routes, error_handlers" should be placed at the top of the module (wrong-import-position)
service/__init__.py:25:4: C0103: Constant name "gunicorn_logger" doesn't conform to UPPER_CASE naming style (invalid-name)
service/__init__.py:29:4: C0103: Constant name "formatter" doesn't conform to UPPER_CASE naming style (invalid-name)
service/__init__.py:44:7: W0703: Catching too general exception Exception (broad-except)
************* Module service.error_handlers
service/error_handlers.py:1:2: W0511: TODO: Copyright header (fixme)
************* Module service.models
service/models.py:1:2: W0511: TODO: Add a license header (fixme)
service/models.py:81:2: W0511: TODO: Not sure about the sku part. Might change it later. (fixme)
service/models.py:17:0: C0103: Constant name "logger" doesn't conform to UPPER_CASE naming style (invalid-name)
service/models.py:20:0: C0103: Constant name "db" doesn't conform to UPPER_CASE naming style (invalid-name)
service/models.py:65:8: C0103: Attribute name "id" doesn't conform to snake_case naming style (invalid-name)
************* Module service.routes
service/routes.py:1:2: W0511: TODO: Add a license header (fixme)
************* Module service.status
service/status.py:1:0: R0401: Cyclic import (service -> service.routes) (cyclic-import)
service/status.py:1:0: R0401: Cyclic import (service -> service.error_handlers) (cyclic-import)

------------------------------------------------------------------
Your code has been rated at 9.26/10 (previous run: 9.26/10, +0.00)
```